### PR TITLE
ci(docker): configure staging environment for Docker image

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -17,6 +17,8 @@ jobs:
       registry-image: ${{ vars.DOCKER_REGISTRY_IMAGE }}
       platforms: '["linux/amd64","linux/arm64"]'
       tags: '["develop"]'
+      environment-name: 'Docker Image Staging'
+      environment-url: ${{ vars.DOCKER_HUB_STAGING_IMAGE_URL }}
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
This pull request makes a small improvement to the deployment workflow by adding environment metadata for the Docker image staging deployment.

- Deployment Workflow Enhancement:
  * [`.github/workflows/deploy-to-staging.yml`](diffhunk://#diff-818403a9415e5b666241623f758313ab88e1348da45e0534f916f2a846fa1394R20-R21): Added `environment-name` and `environment-url` to the Docker image deployment step to provide clearer metadata about the staging environment.