### PR TITLE
ci(sonarcloud): update workflow to skip analysis on Renovate bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,8 +118,13 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis 🌥️
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     needs:
       - unit-tests
+    if: github.actor != 'renovate[bot]'
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5


### PR DESCRIPTION
## 🔗 Related issue(s)

Closes nothing.

## 🌟 Description of changes

This pull request updates the SonarCloud job configuration in the GitHub Actions workflow to improve security, reliability, and efficiency.

**Workflow configuration improvements:**

* Added a timeout of 10 minutes to the `sonarcloud` job to prevent it from running indefinitely.
* Set explicit permissions for the `sonarcloud` job: `contents: read` and `pull-requests: write`, following GitHub Actions best practices.
* Added a conditional to skip the `sonarcloud` job when the actor is `renovate[bot]`, preventing unnecessary analysis on automated dependency update PRs.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-visible changes in this release.**

This update consists of internal infrastructure and automation improvements with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->