### PR TITLE
ci(build): set timeout for Docker build to 10 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
   docker-builds:
     name: Docker Build 🐳
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to nothing.

## 🌟 Description of changes

This pull request makes a minor update to the GitHub Actions workflow by adding a timeout to the Docker build job. This helps prevent jobs from running indefinitely.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build infrastructure configuration to improve CI job reliability.

---

*Note: No end-user facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->