### PR TITLE
chore: update linting configuration and disable consistent-type-imports for oxc

### DIFF
--- a/configs/eslint/flat-configs/eslint-unit-tests.flat-config.ts
+++ b/configs/eslint/flat-configs/eslint-unit-tests.flat-config.ts
@@ -87,6 +87,7 @@ const ESLINT_UNIT_TESTS_FLAT_CONFIG: Linter.Config = {
     "vitest/prefer-to-have-length": "error",
     "vitest/prefer-todo": "error",
     "vitest/prefer-vi-mocked": "error",
+    "vitest/require-awaited-expect-poll": "error",
     "vitest/require-hook": "error",
     "vitest/require-local-test-context-for-concurrent-snapshots": "error",
     "vitest/require-mock-type-parameters": "error",

--- a/configs/oxlint/oxlint.config.jsonc
+++ b/configs/oxlint/oxlint.config.jsonc
@@ -726,7 +726,8 @@
           "type"
         ],
         "typescript/consistent-type-exports": "error",
-        "typescript/consistent-type-imports": "error",
+        // Disabled for now because of false positives because of decorators usage
+        "typescript/consistent-type-imports": "off",
         "typescript/default-param-last": "error",
         "typescript/dot-notation": [
           "error",

--- a/src/app/controllers/app.controller.ts
+++ b/src/app/controllers/app.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get, HttpStatus } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { ZodResponse } from "nestjs-zod";
 
-// oxlint-disable-next-line consistent-type-imports
 import { AppService } from "@app/providers/services/app.service";
 
 import { SwaggerTags } from "@server/constants/swagger.enums";

--- a/src/modules/health/controllers/health.controller.ts
+++ b/src/modules/health/controllers/health.controller.ts
@@ -5,7 +5,6 @@ import { ZodResponse } from "nestjs-zod";
 
 import { SwaggerTags } from "@server/constants/swagger.enums";
 
-// oxlint-disable-next-line consistent-type-imports
 import { HealthService } from "@modules/health/providers/services/health.service";
 import { HEALTH_CHECK_RESULT_SCHEMA } from "@modules/health/constants/health.constants";
 

--- a/src/modules/health/providers/services/health.service.ts
+++ b/src/modules/health/providers/services/health.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@nestjs/common";
-// oxlint-disable-next-line consistent-type-imports
 import { HealthCheckService, HttpHealthIndicator, MongooseHealthIndicator } from "@nestjs/terminus";
 
 import { DOCS_ENDPOINT_HEALTH_KEY, MONGOOSE_HEALTH_KEY } from "@modules/health/constants/health.constants";


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to nothing.

## 🌟 Description of changes

This pull request contains several configuration and code cleanup updates, mainly focused on linting rules and minor code style improvements. The most notable changes are updates to linting configurations to improve code quality and maintainability, and the removal of unnecessary lint rule suppression comments in several files.

**Linting configuration updates:**

* Enabled the `vitest/require-awaited-expect-poll` rule as an error in the `ESLINT_UNIT_TESTS_FLAT_CONFIG` to enforce best practices in unit tests.
* Disabled the `typescript/consistent-type-imports` rule in the `oxlint.config.jsonc` due to false positives when using decorators.

**Code cleanup:**

* Removed unnecessary `oxlint-disable-next-line consistent-type-imports` comments from `app.controller.ts`, `health.controller.ts`, and `health.service.ts` as the related lint rule is now disabled.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test validation for asynchronous operations
  * Resolved linting configuration conflicts
  * Cleaned up codebase configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->