### PR TITLE
feat(mongoose): implement localized text schemas for questions and themes

### DIFF
--- a/src/contexts/question/infrastructure/persistence/mongoose/schemas/question-content/question-content.mongoose.schema.ts
+++ b/src/contexts/question/infrastructure/persistence/mongoose/schemas/question-content/question-content.mongoose.schema.ts
@@ -1,6 +1,8 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 
 import { DEFAULT_SUBDOCUMENT_MONGOOSE_SCHEMA_OPTIONS } from "@shared/infrastructure/persistence/mongoose/constants/mongoose.constants";
+import { LOCALIZED_TEXT_MONGOOSE_SCHEMA } from "@shared/infrastructure/persistence/mongoose/schemas/localization/localized-text.mongoose.schema";
+import { LOCALIZED_TEXTS_MONGOOSE_SCHEMA } from "@shared/infrastructure/persistence/mongoose/schemas/localization/localized-texts.mongoose.schema";
 
 import { LocalizedText, LocalizedTexts } from "@shared/domain/value-objects/locale/locale.types";
 
@@ -10,27 +12,27 @@ import { LocalizedText, LocalizedTexts } from "@shared/domain/value-objects/loca
 class QuestionContentMongooseSchema {
   @Prop({
     required: true,
-    type: Object,
+    type: LOCALIZED_TEXT_MONGOOSE_SCHEMA,
   })
-  public statement!: LocalizedText;
+  public statement!: Partial<LocalizedText>;
 
   @Prop({
     required: true,
-    type: Object,
+    type: LOCALIZED_TEXT_MONGOOSE_SCHEMA,
   })
-  public answer!: LocalizedText;
+  public answer!: Partial<LocalizedText>;
 
   @Prop({
     required: false,
-    type: Object,
+    type: LOCALIZED_TEXT_MONGOOSE_SCHEMA,
   })
-  public context?: LocalizedText;
+  public context?: Partial<LocalizedText>;
 
   @Prop({
     required: false,
-    type: Object,
+    type: LOCALIZED_TEXTS_MONGOOSE_SCHEMA,
   })
-  public trivia?: LocalizedTexts;
+  public trivia?: Partial<LocalizedTexts>;
 }
 
 const QUESTION_CONTENT_MONGOOSE_SCHEMA = SchemaFactory.createForClass(QuestionContentMongooseSchema);

--- a/src/contexts/question/modules/question-theme/infrastructure/persistence/mongoose/schema/question-theme.mongoose.schema.ts
+++ b/src/contexts/question/modules/question-theme/infrastructure/persistence/mongoose/schema/question-theme.mongoose.schema.ts
@@ -1,6 +1,8 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 
 import { DEFAULT_MONGOOSE_SCHEMA_OPTIONS } from "@shared/infrastructure/persistence/mongoose/constants/mongoose.constants";
+import { LOCALIZED_TEXT_MONGOOSE_SCHEMA } from "@shared/infrastructure/persistence/mongoose/schemas/localization/localized-text.mongoose.schema";
+import { LOCALIZED_TEXTS_MONGOOSE_SCHEMA } from "@shared/infrastructure/persistence/mongoose/schemas/localization/localized-texts.mongoose.schema";
 
 import { DEFAULT_QUESTION_THEME_STATUS, QUESTION_THEME_STATUSES } from "@question/modules/question-theme/domain/value-objects/question-theme-status/question-theme-status.constants";
 import { QUESTION_THEME_MONGOOSE_COLLECTION_NAME } from "@question/modules/question-theme/infrastructure/persistence/mongoose/constants/question-theme.mongoose.constants";
@@ -23,21 +25,21 @@ class QuestionThemeMongooseSchema {
 
   @Prop({
     required: true,
-    type: Object,
+    type: LOCALIZED_TEXT_MONGOOSE_SCHEMA,
   })
-  public label!: LocalizedText;
+  public label!: Partial<LocalizedText>;
 
   @Prop({
     required: true,
-    type: Object,
+    type: LOCALIZED_TEXTS_MONGOOSE_SCHEMA,
   })
-  public aliases!: LocalizedTexts;
+  public aliases!: Partial<LocalizedTexts>;
 
   @Prop({
     required: true,
-    type: Object,
+    type: LOCALIZED_TEXT_MONGOOSE_SCHEMA,
   })
-  public description!: LocalizedText;
+  public description!: Partial<LocalizedText>;
 
   @Prop({
     required: true,

--- a/src/shared/infrastructure/persistence/mongoose/schemas/localization/localized-text.mongoose.schema.ts
+++ b/src/shared/infrastructure/persistence/mongoose/schemas/localization/localized-text.mongoose.schema.ts
@@ -1,0 +1,51 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+
+import { DEFAULT_SUBDOCUMENT_MONGOOSE_SCHEMA_OPTIONS } from "@shared/infrastructure/persistence/mongoose/constants/mongoose.constants";
+
+@Schema({
+  ...DEFAULT_SUBDOCUMENT_MONGOOSE_SCHEMA_OPTIONS,
+})
+class LocalizedTextMongooseSchema {
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public en?: string;
+
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public fr?: string;
+
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public es?: string;
+
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public de?: string;
+
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public it?: string;
+
+  @Prop({
+    required: false,
+    type: String,
+  })
+  public pt?: string;
+}
+
+const LOCALIZED_TEXT_MONGOOSE_SCHEMA = SchemaFactory.createForClass(LocalizedTextMongooseSchema);
+
+export {
+  LocalizedTextMongooseSchema,
+  LOCALIZED_TEXT_MONGOOSE_SCHEMA,
+};

--- a/src/shared/infrastructure/persistence/mongoose/schemas/localization/localized-texts.mongoose.schema.ts
+++ b/src/shared/infrastructure/persistence/mongoose/schemas/localization/localized-texts.mongoose.schema.ts
@@ -1,0 +1,57 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+
+import { DEFAULT_SUBDOCUMENT_MONGOOSE_SCHEMA_OPTIONS } from "@shared/infrastructure/persistence/mongoose/constants/mongoose.constants";
+
+@Schema({
+  ...DEFAULT_SUBDOCUMENT_MONGOOSE_SCHEMA_OPTIONS,
+})
+class LocalizedTextsMongooseSchema {
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public en?: string[];
+
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public fr?: string[];
+
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public es?: string[];
+
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public de?: string[];
+
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public it?: string[];
+
+  @Prop({
+    required: false,
+    type: [String],
+    default: undefined,
+  })
+  public pt?: string[];
+}
+
+const LOCALIZED_TEXTS_MONGOOSE_SCHEMA = SchemaFactory.createForClass(LocalizedTextsMongooseSchema);
+
+export {
+  LocalizedTextsMongooseSchema,
+  LOCALIZED_TEXTS_MONGOOSE_SCHEMA,
+};


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to no issue.

## 🌟 Description of changes

This pull request introduces new reusable Mongoose schemas for handling localized text fields, and updates existing question-related schemas to use these new definitions. This change standardizes how localized single and multiple text values are stored in the database, improving consistency and maintainability across the codebase.

**Localization schema improvements:**

* Added `LOCALIZED_TEXT_MONGOOSE_SCHEMA` and `LOCALIZED_TEXTS_MONGOOSE_SCHEMA` in `localized-text.mongoose.schema.ts` and `localized-texts.mongoose.schema.ts` to represent localized single and multiple text fields for supported languages (en, fr, es, de, it, pt).

**Schema updates for questions and themes:**

* Updated `QuestionContentMongooseSchema` and `QuestionThemeMongooseSchema` to use the new localized text schemas for fields such as `statement`, `answer`, `context`, `trivia`, `label`, `aliases`, and `description`, replacing the previous generic `Object` type. These fields are now typed as partials of their respective localized value objects.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
 * Restructured database schemas for question content and theme entities to use specialized multilingual structures. Localized text fields including statements, answers, contexts, trivia, descriptions, and aliases now implement dedicated schemas with standardized language support for English, French, Spanish, German, Italian, and Portuguese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
