### PR TITLE
feat(publish): add workflow for automatic schema publishing to npm

### DIFF
--- a/.github/workflows/publish-schemas-package.yml
+++ b/.github/workflows/publish-schemas-package.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - develop
       - main
+    paths:
+      - 'packages/schemas/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -70,4 +72,4 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         shell: bash
         working-directory: packages/schemas
-        run: pnpm publish --tag "${{ steps.compute-version.outputs.dist-tag }}" --no-git-checks --access public
+        run: pnpm publish --tag "${{ steps.compute-version.outputs.dist-tag }}" --no-git-checks --access public --provenance

--- a/.github/workflows/publish-schemas-package.yml
+++ b/.github/workflows/publish-schemas-package.yml
@@ -1,0 +1,73 @@
+name: 📦 Publish @goat-it/schemas Workflow
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-and-publish:
+    name: Check and publish @goat-it/schemas 📦
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository 📡
+        uses: actions/checkout@v6
+
+      - name: Install project 📦
+        uses: ./.github/actions/install-project
+
+      - name: Compute version and dist-tag 🔢
+        id: compute-version
+        shell: bash
+        run: |
+          BASE_VERSION=$(node -p "require('./packages/schemas/package.json').version")
+          if [ "${{ github.ref_name }}" = "develop" ]; then
+            echo "version=${BASE_VERSION}-beta" >> "$GITHUB_OUTPUT"
+            echo "dist-tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "dist-tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if version already exists on npm 🔍
+        id: check-version
+        shell: bash
+        run: |
+          if npm view "@goat-it/schemas@${{ steps.compute-version.outputs.version }}" version --json 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip publication (version already published) ⏭️
+        if: steps.check-version.outputs.exists == 'true'
+        shell: bash
+        run: echo "Version ${{ steps.compute-version.outputs.version }} already exists on npm – skipping publication."
+
+      - name: Setup Node.js for npm publish 🔧
+        if: steps.check-version.outputs.exists == 'false'
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: configs/node/.node-version
+          registry-url: https://registry.npmjs.org
+
+      - name: Patch package.json version 🔧
+        if: steps.check-version.outputs.exists == 'false'
+        shell: bash
+        working-directory: packages/schemas
+        run: npm version "${{ steps.compute-version.outputs.version }}" --no-git-tag-version
+
+      - name: Publish @goat-it/schemas to npm 🚀
+        if: steps.check-version.outputs.exists == 'false'
+        shell: bash
+        working-directory: packages/schemas
+        run: pnpm publish --tag "${{ steps.compute-version.outputs.dist-tag }}" --no-git-checks --access public


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to no issue.

## 🌟 Description of changes

This pull request introduces a new GitHub Actions workflow for automating the publication of the `@goat-it/schemas` package. The workflow handles version computation, checks for existing versions, and publishes to npm with appropriate tags, streamlining the release process for both `develop` and `main` branches.

Automation of package publishing:

* Added `.github/workflows/publish-schemas-package.yml` to automate publishing of `@goat-it/schemas` to npm, including version computation, dist-tag assignment, and conditional publishing based on branch and existing versions.

CI/CD improvements:

* Implemented concurrency control to prevent overlapping publish jobs and ensure only one publish workflow runs at a time.
* Integrated steps for checking out the repository, installing the project, setting up Node.js, patching the package version, and publishing with `pnpm` only if the version does not already exist on npm.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
 * Added an automated publishing workflow for the schemas package: branch-based versioning (beta for develop, latest for main), pre-publish check that skips already-published versions, publishes via pnpm with public access, no git tagging, and a 10-minute job timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
