### PR TITLE
chore(package): allow package version to be the same when publishing

### DIFF
--- a/.github/workflows/publish-schemas-package.yml
+++ b/.github/workflows/publish-schemas-package.yml
@@ -62,11 +62,11 @@ jobs:
           node-version-file: configs/node/.node-version
           registry-url: https://registry.npmjs.org
 
-      - name: Patch package.json version 🔧
+      - name: Patch package.json version if necessary 🔧
         if: steps.check-version.outputs.exists == 'false'
         shell: bash
         working-directory: packages/schemas
-        run: npm version "${{ steps.compute-version.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ steps.compute-version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Publish @goat-it/schemas to npm 🚀
         if: steps.check-version.outputs.exists == 'false'

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@goat-it/schemas",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Shared types, constants and Zod schemas for the Goat It projects.",
   "scripts": {
     "dev": "tsdown --watch",


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to nothing.

## 🌟 Description of changes

This pull request contains a minor update to the `@goat-it/schemas` package version and a small improvement to the publish workflow. The change ensures that the package version can be patched even if the version has not changed.

* Version bump:
 * Updated the `version` field in `packages/schemas/package.json` from `0.0.4` to `0.0.5` to prepare for a new package release.

* Publish workflow improvement:
 * Modified the publish step in `.github/workflows/publish-schemas-package.yml` to allow patching the version even if it matches the current version, by adding the `--allow-same-version` flag to the `npm version` command.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
 * Updated schemas package version to 0.0.5
 * Enhanced version management workflow configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
