### PR TITLE
docs(agents): add acceptance test guide to AGENTS.md

### DIFF
--- a/.agents/skills/write-acceptance-test/SKILL.md
+++ b/.agents/skills/write-acceptance-test/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: write-acceptance-test
+description: Write or complete a Cucumber/Gherkin acceptance test scenario for any feature in the Goat It API, following the conventions in tests/acceptance/README.md (fixtures, payloads, step definitions, DataTable schemas, locale helpers).
+disable-model-invocation: true
+---
+
+## What I do
+
+- Identify the feature, audience (admin/public) and domain to determine the correct file locations
+- Write or complete `.feature` files with properly tagged scenarios
+- Add or reuse fixture sets and register them in `FIXTURE_REGISTRY`
+- Add or reuse payload constants and register them in `PAYLOADS`
+- Write `Given`, `When`, `Then` step definitions following naming and regex conventions
+- Define DataTable schemas using `z.strictObject` + `zCoerceOptional*` helpers
+- Write step helpers (pure assertion functions) for non-trivial Then assertions
+- Run `pnpm test:acceptance` (or `SKIP_BUILD=true pnpm test:acceptance`) until the suite is green
+
+## When to use me
+
+- A new HTTP endpoint needs BDD coverage from feature file to step definitions
+- An existing feature scenario is missing validation-error or boundary-case coverage
+- Fixture sets or payloads need to be added for a new domain
+
+## Golden rule
+
+**Always read `tests/acceptance/README.md` before writing or completing any acceptance test.** It contains authoritative templates, conventions, and reference links for every part of the acceptance test system.
+
+## Lifecycle recap
+
+The suite (hooks in `tests/acceptance/support/hooks.ts`):
+
+1. **BeforeAll**: loads `.env.test`, optionally builds the app, connects MongoDB, spawns the app.
+2. **Before** (each scenario): drops and recreates all MongoDB collections; attaches `appProcess` to world.
+3. **After** (each scenario — failure only): flushes app log ring buffer; prints world debug dump.
+4. **AfterAll**: disconnects MongoDB, kills app process.
+
+## GoatItWorld quick reference
+
+```typescript
+// In any step function:
+function (this: GoatItWorld) {
+  // Set up payload (Given)
+  this.payload = { ... };
+
+  // Fire request (When)
+  await this.fetchAndStoreResponse("/some/endpoint", createFetchOptions({
+    apiKey: APP_ADMIN_API_KEY,
+    method: "POST",
+    body: this.payload,
+  }));
+
+  // Parse response (Then)
+  const dto = this.expectLastResponseJson<MyDto>(MY_DTO_SCHEMA);
+
+  // Assert HTTP status (Then, via shared step)
+  // "the request should have succeeded with status code 201"
+}
+```
+
+## Feature file template
+
+```gherkin
+@<domain> @<feature-slug> @<audience>
+
+Feature: <Descriptive Feature Name>
+  In order to <goal>
+  As a <role> API client
+  I want to <action>
+
+  Scenario: Happy path description
+    Given the database is populated with <domain> fixture set with name "<set-name>"
+    And the request payload is set from scope "<scope>", type "<type>" and name "<name>"
+    When <the audience> <performs the action> with the request payload
+    Then the request should have succeeded with status code <2xx>
+    And the response should contain the following <entity>:
+      | field1 | field2 |
+      | <SET>  | value  |
+
+  Scenario: Validation error description
+    Given the database is populated with <domain> fixture set with name "<set-name>"
+    And the request payload is set from scope "<scope>", type "<type>" and name "<name>"
+    When the request payload is overridden with the following values:
+      | path  | type   | value |
+      | field | string |       |
+    And <the audience> <performs the action> with the request payload
+    Then the request should have failed with status code 400 and the response should contain the following error:
+      | error       | statusCode | message                 | validationDetails |
+      | Bad Request | 400        | Invalid request payload | <SET>             |
+    And the failed request's response should contain the following validation details:
+      | code      | message        | path  | origin | minimum | inclusive |
+      | too_small | Too small: ... | field | string | 1       | true      |
+```
+
+## Step definition templates
+
+### Given — load fixture
+
+```typescript
+import { Given } from "@cucumber/cucumber";
+import { loadFixture } from "@acceptance-support/fixtures/helpers/fixture.helpers";
+import type { GoatItWorld } from "@acceptance-support/types/world.types";
+
+Given(/^the database is populated with <domain> fixture set with name "(?<name>[^"]+)"$/u, async function (this: GoatItWorld, name: string) {
+  await loadFixture(this, "<domain>", name as "<set-name>");
+});
+```
+
+### When — fire HTTP request
+
+```typescript
+import { When } from "@cucumber/cucumber";
+import { APP_ADMIN_API_KEY } from "@acceptance-support/constants/app.constants";
+import { createFetchOptions } from "@acceptance-support/helpers/request.helpers";
+import type { GoatItWorld } from "@acceptance-support/types/world.types";
+
+When(/^the admin creates a new <entity> with the request payload$/u, async function (this: GoatItWorld) {
+  const fetchOptions = createFetchOptions({
+    apiKey: APP_ADMIN_API_KEY,
+    method: "POST",
+    body: this.payload,
+  });
+  await this.fetchAndStoreResponse("/<endpoint>", fetchOptions);
+});
+```
+
+### Then — assert response
+
+```typescript
+import { Then } from "@cucumber/cucumber";
+import { expect } from "expect";
+import { validateDataTableAndGetFirstRow } from "@acceptance-support/helpers/datatable.helpers";
+import { MY_DATATABLE_SCHEMA } from "@acceptance-features/step-definitions/contexts/<domain>/<audience>/datatables/<domain>.datatables.schemas";
+import { MY_RESPONSE_DTO } from "@<domain>/application/dto/<entity>/<entity>.dto.shape";
+import type { DataTable } from "@cucumber/cucumber";
+import type { GoatItWorld } from "@acceptance-support/types/world.types";
+
+Then(/^the response should contain the following <entity>:$/u, function (this: GoatItWorld, dataTable: DataTable) {
+  const row = validateDataTableAndGetFirstRow(dataTable, MY_DATATABLE_SCHEMA);
+  const dto = this.expectLastResponseJson<MyDto>(MY_RESPONSE_DTO);
+  expect(dto.someField).toStrictEqual(row.someField);
+});
+```
+
+## DataTable schema template
+
+```typescript
+import { z } from "zod";
+import { zCoerceOptionalBoolean, zCoerceOptionalString } from "@acceptance-support/helpers/datatable.helpers";
+
+const MY_ROW_SCHEMA = z.strictObject({
+  id: z.string(),                      // required string
+  isActive: zCoerceOptionalBoolean(),  // optional boolean (empty string → undefined)
+  description: zCoerceOptionalString(), // optional string (empty string → undefined)
+});
+
+export { MY_ROW_SCHEMA };
+```
+
+## Fixture set template
+
+```typescript
+import type { QuestionThemeMongooseDocumentStub } from "@mocks/contexts/question/modules/question-theme/infrastructure/persistence/mongoose/question-theme.mongoose.types.mock";
+import { createFakeQuestionThemeDocument } from "@faketories/contexts/question/question-theme/mongoose/mongoose-document/question-theme.mongoose-document.faketory";
+import { createFakeObjectId } from "@faketories/infrastructure/database/database.faketory";
+
+const MY_FIXTURE_ENTRY = createFakeQuestionThemeDocument({
+  _id: createFakeObjectId("aabbccddeeff001122334455"), // ... deterministic field overrides
+});
+
+const MY_FIXTURE_SET = [
+  MY_FIXTURE_ENTRY,
+  // ...
+] as const satisfies ReturnType<typeof createFakeQuestionThemeDocument>[];
+
+export { MY_FIXTURE_SET, MY_FIXTURE_ENTRY };
+```
+
+## Payload template
+
+```typescript
+import { MY_FIXTURE_ENTRY } from "@acceptance-support/fixtures/<domain>/sets/my-set.fixture-set";
+
+const MY_PAYLOAD = {
+  // deterministic values; reference fixture IDs for foreign keys
+  themeId: MY_FIXTURE_ENTRY._id.toString(),
+  name: "Some Name",
+} as const;
+
+export { MY_PAYLOAD };
+```
+
+## Payload override types
+
+| `type` in DataTable | Parsed as                                                     |
+|---------------------|---------------------------------------------------------------|
+| `string`            | Raw string (quotes stripped if wrapped in `"..."` or `'...'`) |
+| `integer`           | `Number.parseInt(value, 10)`                                  |
+| `float`             | `Number.parseFloat(value)`                                    |
+| `boolean`           | `true` or `false`                                             |
+| `array`             | `JSON.parse(value)` — must be a valid JSON array              |
+| `undefined`         | `undefined` (removes the key from the payload)                |
+
+## File naming conventions
+
+| File type         | Location                                                                   | Naming pattern                            |
+|-------------------|----------------------------------------------------------------------------|-------------------------------------------|
+| Feature file      | `tests/acceptance/features/contexts/<domain>/<audience>/`                  | `<action>-<entity>-as-<audience>.feature` |
+| Given steps       | `tests/acceptance/features/step-definitions/contexts/<domain>/<audience>/` | `<domain>[-<sub>].given-steps.ts`         |
+| When steps        | same                                                                       | `<domain>[-<sub>].when-steps.ts`          |
+| Then steps        | same                                                                       | `<domain>[-<sub>].then-steps.ts`          |
+| DataTable schemas | same, `datatables/` subfolder                                              | `<domain>.datatables.schemas.ts`          |
+| Step helpers      | same, `helpers/` subfolder                                                 | `<domain>.steps.helpers.ts`               |
+| Fixture set       | `tests/acceptance/support/fixtures/<domain>/sets/`                         | `<set-name>.fixture-set.ts`               |
+| Fixture index     | `tests/acceptance/support/fixtures/<domain>/`                              | `<domain>.fixtures.ts`                    |
+| Payload           | `tests/acceptance/support/payloads/<scope>/<type>/`                        | `<name>-<scope>.<type>-payload.ts`        |
+
+## Checks to run when done
+
+```bash
+SKIP_BUILD=true pnpm test:acceptance   # if dist/ is already built
+pnpm test:acceptance                   # full run with build
+pnpm run typecheck
+pnpm run lint
+```
+
+## Reference
+
+- **Primary authoritative guide (read first):** `tests/acceptance/README.md`
+- Lifecycle and World: `tests/acceptance/support/hooks.ts`, `tests/acceptance/support/types/world.types.ts`
+- Fixture registry: `tests/acceptance/support/fixtures/constants/fixture.constants.ts`
+- Payload registry: `tests/acceptance/support/payloads/constants/payload.constants.ts`
+- Shared steps: `tests/acceptance/features/step-definitions/shared/request/`
+- DataTable helpers: `tests/acceptance/support/helpers/datatable.helpers.ts`
+- Architecture and data-flow: `docs/ARCHITECTURE.md`
+- Faketory conventions: `tests/shared/utils/faketories/README.md`

--- a/.opencode/commands/write-acceptance-test.md
+++ b/.opencode/commands/write-acceptance-test.md
@@ -1,0 +1,8 @@
+---
+description: Write or complete a Cucumber acceptance test scenario for a given feature or endpoint.
+agent: build
+---
+
+Load the `write-acceptance-test` skill and follow its workflow to write or complete the acceptance test for: $ARGUMENTS
+
+Read `tests/acceptance/README.md` first as instructed by the skill, identify the feature, audience and domain, apply the matching templates for feature file, step definitions, fixtures and payloads, then run the checks until the suite is green.

--- a/.opencode/skills/write-acceptance-test/SKILL.md
+++ b/.opencode/skills/write-acceptance-test/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: write-acceptance-test
+description: Write or complete a Cucumber/Gherkin acceptance test scenario for any feature in the Goat It API, following the conventions in tests/acceptance/README.md (fixtures, payloads, step definitions, DataTable schemas, locale helpers).
+disable-model-invocation: true
+---
+
+The canonical skill definition lives in `.agents/skills/write-acceptance-test/SKILL.md`.
+
+Load that skill for feature-file templates, step-definition patterns, fixture/payload conventions, DataTable schema helpers and reference links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,12 @@ In-depth guides live under `docs/` and `tests/`:
 | `docs/FAKETORIES.md`                      | Pointer to `tests/shared/utils/faketories/README.md`                                    |
 | `docs/MOCKS.md`                           | Pointer to `tests/unit/utils/mocks/README.md`                                           |
 | `docs/UNIT-TESTS.md`                      | Pointer to `tests/unit/README.md`                                                       |
+| `docs/ACCEPTANCE-TESTS.md`               | Pointer to `tests/acceptance/README.md`                                                 |
 | `docs/BRUNO.md`                           | Bruno API collection setup (`configs/bruno/Goat It/`)                                   |
 | `tests/unit/README.md`                    | Full writing guide per file type (controllers, use-cases, repos, DTOs, helpers, errors) |
 | `tests/unit/utils/mocks/README.md`        | Mock factory conventions and anti-patterns                                              |
 | `tests/shared/utils/faketories/README.md` | Faketory conventions, organization and anti-patterns                                    |
+| `tests/acceptance/README.md`              | Acceptance test guide (Cucumber, fixtures, payloads, step definitions, DataTable helpers) |
 
 ---
 
@@ -39,11 +41,12 @@ Reusable agent workflows are encoded as **skills** — self-contained `SKILL.md`
 
 | Skill             | Slash command      | Purpose                                                                                                                                             |
 |-------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `create-faketory` | `/create-faketory` | Scaffold a faketory (test data factory) for an entity, DTO, command or Mongoose document                                                            |
-| `create-mock`     | `/create-mock`     | Scaffold a typed Vitest mock factory for a repository or use-case port                                                                              |
-| `write-unit-test` | `/write-unit-test` | Write or complete a unit test file following 100%-coverage conventions                                                                              |
-| `create-skill`    | `/create-skill`    | Scaffold a new agent skill following repository conventions                                                                                         |
-| `challenge-plan`  | `/challenge-plan`  | Challenge a new feature idea by exploring the codebase, proposing evidence-backed answers, and producing a zero-ambiguity implementation-ready plan |
+| `create-faketory`       | `/create-faketory`       | Scaffold a faketory (test data factory) for an entity, DTO, command or Mongoose document                                                            |
+| `create-mock`           | `/create-mock`           | Scaffold a typed Vitest mock factory for a repository or use-case port                                                                              |
+| `write-unit-test`       | `/write-unit-test`       | Write or complete a unit test file following 100%-coverage conventions                                                                              |
+| `write-acceptance-test` | `/write-acceptance-test` | Write or complete a Cucumber acceptance test scenario for any feature or endpoint                                                                    |
+| `create-skill`          | `/create-skill`          | Scaffold a new agent skill following repository conventions                                                                                         |
+| `challenge-plan`        | `/challenge-plan`        | Challenge a new feature idea by exploring the codebase, proposing evidence-backed answers, and producing a zero-ambiguity implementation-ready plan |
 
 ### Adding a new skill
 

--- a/docs/ACCEPTANCE-TESTS.md
+++ b/docs/ACCEPTANCE-TESTS.md
@@ -1,0 +1,9 @@
+# Acceptance Tests Guide
+
+This document points to `tests/acceptance/README.md` that contains the detailed "How To" and repository-specific examples. It briefly describes where acceptance tests live and the runtime expectations.
+
+- Feature files live under `tests/acceptance/features/` as `*.feature` files; support code (hooks, world, fixtures, payloads, helpers) lives under `tests/acceptance/support/`.
+- Runner: Cucumber.js with `tsx/cjs` for TypeScript transpilation. Tests run serially against a spawned production build of the app backed by a real MongoDB test database.
+- Build: `pnpm test:acceptance`. Set `SKIP_BUILD=true` to skip the NestJS build when `dist/` is already up to date.
+
+See `tests/acceptance/README.md` for the full writing guidelines (lifecycle, GoatItWorld, fixtures, payloads, step definitions, DataTable helpers, locale helpers).

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,666 @@
+# Acceptance Tests — Guidelines
+
+## Table of Contents
+
+- [Purpose & Location](#purpose--location)
+- [Stack & Config](#stack--config)
+- [Directory Layout](#directory-layout)
+- [How to Run](#how-to-run)
+- [Lifecycle & Hooks](#lifecycle--hooks)
+- [GoatItWorld (Custom World)](#goatitworld-custom-world)
+- [Fixtures](#fixtures)
+- [Payloads](#payloads)
+- [Step Definitions](#step-definitions)
+  - [General Rules](#general-rules)
+  - [Given Steps](#given-steps)
+  - [When Steps](#when-steps)
+  - [Then Steps](#then-steps)
+  - [Shared Steps](#shared-steps)
+- [DataTable Helpers](#datatable-helpers)
+- [Locale Helpers](#locale-helpers)
+- [Request Helpers](#request-helpers)
+- [Feature Files](#feature-files)
+- [Logging & Debugging](#logging--debugging)
+- [Path Aliases](#path-aliases)
+- [How To: Add a New Acceptance Test](#how-to-add-a-new-acceptance-test)
+
+---
+
+## Purpose & Location
+
+Acceptance tests verify end-to-end behavior of the HTTP API by exercising real HTTP endpoints against a running application backed by a real MongoDB test database. They complement unit tests by proving that all layers — controller, use-case, repository, database — integrate correctly.
+
+Feature files live under `tests/acceptance/features/`. Support code (hooks, world, fixtures, payloads, helpers) lives under `tests/acceptance/support/`.
+
+---
+
+## Stack & Config
+
+- **Framework**: [Cucumber.js](https://github.com/cucumber/cucumber-js) with BDD/Gherkin `.feature` files.
+- **TypeScript transpilation**: `tsx/cjs` (via `requireModule` in Cucumber config) — no separate compilation step required.
+- **HTTP client**: `ofetch` (auto-serializes JSON, captures responses regardless of HTTP status).
+- **Assertions**: `expect` from the `expect` package (same API as Vitest/Jest).
+- **Payload patching**: `radashi` (`crush` + `construct`) for deep-path overrides.
+- **Cucumber config**: `configs/cucumber/cucumber.json`.
+- **TypeScript config**: `configs/typescript/tsconfig.acceptance.json` (extends `tsconfig.app.json`; includes `src/**`, faketories, shared helpers, mock type stubs, and `tests/acceptance/**`).
+- **Parallelism**: serial only (`"parallel": 1`) — scenarios share a single app process and database.
+- **Reports output**: `tests/acceptance/reports/` — JUnit XML (`junit.xml`), JSON (`report.json`), and Cucumber message format (`message.json`).
+
+---
+
+## Directory Layout
+
+```
+tests/acceptance/
+  features/
+    app/                             # App-level features (health, docs, metadata)
+    contexts/
+      question/                      # Domain features per audience
+        admin/                       # Admin-facing question scenarios
+        public/                      # Public-facing question scenarios
+        question-theme/              # Question-theme management scenarios
+    step-definitions/
+      app/                           # Step implementations for app-level features
+      contexts/
+        question/
+          admin/                     # Admin question Given/When/Then steps
+          public/                    # Public question Given/When/Then steps
+          question-theme/            # Question-theme Given/When/Then steps
+      shared/
+        locale/                      # Locale assertion helpers and datatable schemas
+        request/                     # Shared Given/When/Then steps for request setup
+  support/
+    constants/                       # App URL, API keys, HTTP status lists, logging consts
+    fixtures/
+      constants/fixture.constants.ts # FIXTURE_REGISTRY + FIXTURE_INSERTERS
+      helpers/fixture.helpers.ts     # loadFixture() with dependency resolution
+      types/fixture.types.ts         # FixtureRegistry, FixtureDefinition, FixtureInserter types
+      question/                      # question.fixtures.ts + sets/*.fixture-set.ts
+      question-theme/                # question-theme.fixtures.ts + sets/*.fixture-set.ts
+    helpers/
+      datatable.helpers.ts           # zCoerceOptional* validators, validateDataTable* helpers
+      request.helpers.ts             # createFetchOptions(), createFetchHeaders()
+      setup/
+        build.helpers.ts             # buildAppForAcceptanceTests()
+        env.helpers.ts               # loadEnvTestConfig()
+        http.helpers.ts              # waitForAppToBeReady()
+        logging.helpers.ts           # RingBuffer, flushAndPrintLogTail, log handlers
+        process.helpers.ts           # killAppProcess()
+        setup.helpers.ts             # serveAppForAcceptanceTests(), printDebugOnScenarioFailure()
+      test-database.helpers.ts       # connectToTestDatabase, resetTestDatabase, closeTestDatabaseConnection
+    payloads/
+      constants/payload.constants.ts # PAYLOADS registry keyed by scope/type/name
+      types/payload.types.ts         # PayloadScope, PayloadType
+      question/creation/             # COMPLETE_QUESTION_CREATION_PAYLOAD
+      question/question-theme-assignment/ # PRIMARY_HISTORY_QUESTION_THEME_ASSIGNMENT_CREATE_PAYLOAD
+      question-theme/creation/       # COMPLETE_QUESTION_THEME_CREATION_PAYLOAD
+    types/
+      app.types.ts                   # AppFetchOptions
+      hooks.types.ts                 # AcceptanceHooksProcesses, AppLogsManager, AppLogsFlushResult
+      world.types.ts                 # GoatItWorld class
+  logs/                              # Per-run stdout/stderr of the app process (runtime only)
+  plugins/html-reporter/             # HTML reporter plugin
+  reports/                           # JUnit/JSON/message output files
+```
+
+---
+
+## How to Run
+
+```bash
+# Full acceptance test suite (requires Docker services)
+pnpm test:acceptance
+
+# Skip the NestJS build step (useful when the dist/ is already fresh)
+SKIP_BUILD=true pnpm test:acceptance
+```
+
+> **Prerequisites**: MongoDB must be running and reachable at the URL defined in `env/.env.test`. The suite builds the app (`pnpm build`) by default before spawning the server process. Set `SKIP_BUILD=true` to skip the build.
+
+---
+
+## Lifecycle & Hooks
+
+All hooks live in `tests/acceptance/support/hooks.ts`. They execute in this order per test run:
+
+### `BeforeAll`
+
+1. Loads `env/.env.test` via `loadEnvTestConfig()`.
+2. Optionally builds the app (`buildAppForAcceptanceTests()`) unless `SKIP_BUILD=true`.
+3. Connects to MongoDB via `connectToTestDatabase()`.
+4. Spawns `pnpm run start:prod:test` and waits for the HTTP health endpoint to respond (`serveAppForAcceptanceTests()`). The app listens on `http://0.0.0.0:4242`.
+5. Stores the child process reference and log manager in the `processes` object.
+
+### `Before` (each scenario)
+
+1. Drops and recreates all MongoDB collections via `resetTestDatabase()` — every scenario starts with a clean database.
+2. Attaches the app `ChildProcess` to `this.appProcess` on the `GoatItWorld` instance.
+
+### `After` (each scenario — failure only)
+
+1. If the scenario **failed**, flushes the app's stdout/stderr ring buffer and prints the tail to the console via `flushAndPrintLogTail()`.
+2. Calls `printDebugOnScenarioFailure(world, scenario)` to print the World state (last request, last payload, last response) for debugging.
+
+### `AfterAll`
+
+1. Disconnects MongoDB via `closeTestDatabaseConnection()`.
+2. Kills the app process via `killAppProcess()`.
+
+---
+
+## GoatItWorld (Custom World)
+
+Defined in `tests/acceptance/support/types/world.types.ts`. Registered with `setWorldConstructor(GoatItWorld)` in hooks.
+
+All step function bodies must declare `this: GoatItWorld`.
+
+### Properties
+
+| Property            | Type                                          | Description                                                                                               |
+|---------------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `lastFetchResponse` | `FetchResponse<unknown> \| undefined`         | The raw `ofetch` response from the last HTTP call.                                                        |
+| `appProcess`        | `ChildProcessWithoutNullStreams \| undefined` | Reference to the running app child process.                                                               |
+| `models`            | `{ questions, questionThemes }`               | Mongoose `Model` instances for direct DB access in fixtures.                                              |
+| `payload`           | `Record<string, unknown>`                     | The pending request body. Built by Given steps, consumed by When steps. Reset to `{}` after each request. |
+| `lastPayload`       | `Record<string, unknown>`                     | Snapshot of `payload` taken just before each request fires.                                               |
+
+### Methods
+
+| Method                                           | Description                                                                                                                                               |
+|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fetchAndStoreResponse(endpoint, fetchOptions?)` | Fires the request via the `ofetch` instance. Swallows `ofetch` errors so that non-2xx responses are still stored in `lastFetchResponse` without throwing. |
+| `expectLastResponseJson<T>(schema)`              | Parses `lastFetchResponse._data` through the provided Zod schema and returns typed `T`. Throws if no response is stored.                                  |
+| `expectLastResponseText()`                       | Returns `lastFetchResponse._data` as a raw string. Throws if the data is not a string.                                                                    |
+
+### Internal details
+
+- The `ofetch` instance is created once per world with `baseURL: http://0.0.0.0:4242`.
+- The `onRequest` hook clears `lastFetchResponse`, snapshots `payload` into `lastPayload`, and resets `payload` to `{}`.
+- The `onResponse` hook stores the raw response in `lastFetchResponse`.
+- Mongoose models are registered directly from source schemas (`QUESTION_MONGOOSE_SCHEMA`, `QUESTION_THEME_MONGOOSE_SCHEMA`) so the same schema definitions used by the app are reused.
+
+---
+
+## Fixtures
+
+Fixtures are pre-built sets of Mongoose document stubs inserted into the test database by `Given` steps. They provide a deterministic, known state for scenarios to query or reference.
+
+### Registry and inserters
+
+`tests/acceptance/support/fixtures/constants/fixture.constants.ts` defines two constants:
+
+- **`FIXTURE_REGISTRY`**: maps `domain → name → { data, dependencies? }`.
+  - `data`: a `readonly` array of Mongoose document stubs built using faketories from `@faketories/...`.
+  - `dependencies`: optional array of `[domain, name]` tuples that must be loaded before this fixture.
+- **`FIXTURE_INSERTERS`**: maps each domain to an async function that calls `world.models.<collection>.insertMany(data)`.
+
+### Loading fixtures: `loadFixture`
+
+```ts
+import { loadFixture } from "@acceptance-support/fixtures/helpers/fixture.helpers";
+
+await loadFixture(world, "question-theme", "five-question-themes");
+await loadFixture(world, "question", "five-questions"); // auto-loads its question-theme dependency first
+```
+
+- Dependencies are resolved recursively and in declared order.
+- Circular dependency detection throws an error immediately.
+- The `loadedKeys` parameter is internal — never pass it when calling externally.
+
+### Available fixture sets
+
+| Domain           | Name                               | Dependencies                                      | Description                                              |
+|------------------|------------------------------------|---------------------------------------------------|----------------------------------------------------------|
+| `question-theme` | `five-question-themes`             | —                                                 | Five question themes (science, history, geography, …).   |
+| `question-theme` | `two-english-only-question-themes` | —                                                 | Two themes with English labels only.                     |
+| `question`       | `five-questions`                   | `question-theme/five-question-themes`             | Five questions referencing the five-question-themes set. |
+| `question`       | `two-english-only-questions`       | `question-theme/two-english-only-question-themes` | Two questions with English content only.                 |
+
+### Fixture entries
+
+Individual document stubs within a set are exported as named constants (e.g., `FIVE_QUESTION_THEMES_FIXTURE_SCIENCE_ENTRY`) so that payloads can reference their `_id` values and assertions can compare specific records.
+
+### Fixture file conventions
+
+- Sets live under `support/fixtures/<domain>/sets/<set-name>.fixture-set.ts`.
+- Each set is typed as `as const satisfies ReturnType<typeof createFake...Document>[]`.
+- IDs are deterministic (hardcoded `Types.ObjectId` values) so payloads and assertions remain stable across runs.
+
+### Adding a new fixture set
+
+1. Create the set file under `support/fixtures/<domain>/sets/<set-name>.fixture-set.ts`.
+2. Export individual entry constants you may need in payloads or assertions.
+3. Register it in `FixtureRegistry` (type, `fixture.types.ts`) and `FIXTURE_REGISTRY` (constant, `fixture.constants.ts`).
+4. Add a `FIXTURE_INSERTERS` entry if you are introducing a new domain.
+
+---
+
+## Payloads
+
+Payloads are deterministic request body objects that are set by `Given` steps and consumed by `When` steps.
+
+### Registry
+
+`tests/acceptance/support/payloads/constants/payload.constants.ts` exports a `PAYLOADS` constant typed as:
+
+```ts
+Record<PayloadScope, Record<PayloadType, Record<string, object>>>
+```
+
+Addressed in feature files by three coordinates: **scope**, **type**, and **name**.
+
+### Available payloads
+
+| Scope                       | Type       | Name             | Description                                                                                                         |
+|-----------------------------|------------|------------------|---------------------------------------------------------------------------------------------------------------------|
+| `question`                  | `creation` | `complete`       | A complete valid question creation body. References `FIVE_QUESTION_THEMES_FIXTURE_SCIENCE_ENTRY._id` for theme IDs. |
+| `question-theme`            | `creation` | `complete`       | A complete valid question-theme creation body.                                                                      |
+| `question-theme-assignment` | `creation` | `primaryHistory` | A question-theme assignment body for the primary history theme.                                                     |
+
+### Payload file conventions
+
+- Files live under `support/payloads/<domain>/<type>/<name>-<domain>.<type>-payload.ts`.
+- Payloads are built using faketories overridden with concrete, deterministic values (no `faker` randomness).
+- They reference fixture entry `_id`s (e.g., `FIVE_QUESTION_THEMES_FIXTURE_SCIENCE_ENTRY._id.toString()`) to match what will be in the database.
+
+### Overriding payload values
+
+The shared `When` step `the request payload is overridden with the following values:` deep-patches `world.payload` using a DataTable:
+
+```gherkin
+When the request payload is overridden with the following values:
+| path           | type    | value     |
+| author.role    | string  | ai        |
+| author.name    | string  | GoatItGPT |
+| themes[0].isPrimary | boolean | false  |
+| optional       | undefined |         |
+```
+
+- **`path`**: dot-notation or bracket-notation path into the payload object.
+- **`type`**: one of `string`, `integer`, `float`, `boolean`, `array`, `undefined`.
+- **`value`**: the new value (parsed according to `type`; leave empty for `undefined`).
+- `array` values must be valid JSON arrays (e.g., `["a", "b"]`).
+- `string` values wrapped in `"..."` or `'...'` have their quotes stripped.
+
+Patching uses `crush` (flatten to dot paths) and `construct` (rebuild nested object) from `radashi`, so you can target deeply nested fields and array indices safely.
+
+---
+
+## Step Definitions
+
+### General Rules
+
+- Step files are named `<domain>[-<sub>].<given|when|then>-steps.ts` and colocated under the matching `step-definitions/` subfolder.
+- Step regex patterns use named capture groups: `/^the admin retrieves the question with id "(?<id>[^"]+)"$/u`.
+- All step functions declare `this: GoatItWorld` as their first parameter.
+- Step helpers (pure assertion/utility functions) live in `helpers/` subfolders next to the step files. They are **not** step definitions — they are called by Then steps to keep step bodies readable.
+- DataTable schemas live in `datatables/` subfolders next to the step files.
+
+### Given Steps
+
+`Given` steps set up the preconditions for a scenario: database state and request payload.
+
+**Loading a fixture set:**
+
+```gherkin
+Given the database is populated with question themes fixture set with name "five-question-themes"
+Given the database is populated with question fixture set with name "five-questions"
+```
+
+These steps call `loadFixture(world, domain, name)`. Domain-specific `Given` steps live alongside the domain's step files.
+
+**Setting the request payload:**
+
+```gherkin
+Given the request payload is set from scope "question", type "creation" and name "complete"
+```
+
+This shared step looks up `PAYLOADS[scope][type][name]` and assigns the result to `world.payload`. An error is thrown if the combination does not exist.
+
+### When Steps
+
+`When` steps fire HTTP requests. Each step builds a `FetchOptions` object via `createFetchOptions()` and calls `this.fetchAndStoreResponse(endpoint, options)`.
+
+**Typical pattern:**
+
+```ts
+When(/^the admin creates a new question with the request payload$/u, async function (this: GoatItWorld) {
+  const fetchOptions = createFetchOptions({
+    apiKey: APP_ADMIN_API_KEY,
+    method: "POST",
+    body: this.payload,
+  });
+  await this.fetchAndStoreResponse("/admin/questions", fetchOptions);
+});
+```
+
+**Overriding the payload (shared When step):**
+
+```gherkin
+When the request payload is overridden with the following values:
+| path  | type   | value |
+| ...   | ...    | ...   |
+```
+
+See [Payloads — Overriding payload values](#overriding-payload-values) for the full DataTable format.
+
+### Then Steps
+
+`Then` steps assert on the response. They call `this.expectLastResponseJson<T>(ZOD_SCHEMA)` to parse `lastFetchResponse._data`, then use `expect` to assert.
+
+**Typical pattern:**
+
+```ts
+Then(/^the response should contain the following admin question:$/u, function (this: GoatItWorld, dataTable: DataTable) {
+  const row = validateDataTableAndGetFirstRow(dataTable, ADMIN_QUESTION_DATATABLE_SCHEMA);
+  const question = this.expectLastResponseJson<AdminQuestionDto>(ADMIN_QUESTION_DTO);
+  expectAdminQuestionDtoToMatch(question, row);
+});
+```
+
+**The `<SET>` placeholder:**
+
+When a DataTable cell contains `<SET>`, it means the field is expected to be present and truthy (non-null, non-empty), and its actual value is captured for reuse in later steps of the same scenario. This is used for generated IDs where the exact value cannot be known at authoring time.
+
+### Shared Steps
+
+Shared step definitions live under `features/step-definitions/shared/` and are available to all feature files.
+
+#### Shared `Given` steps (`shared/request/request.given-steps.ts`)
+
+| Step                                                                               | Action                                             |
+|------------------------------------------------------------------------------------|----------------------------------------------------|
+| `the request payload is set from scope "<scope>", type "<type>" and name "<name>"` | Sets `world.payload` from the `PAYLOADS` registry. |
+
+#### Shared `When` steps (`shared/request/request.when-steps.ts`)
+
+| Step                                                           | Action                                                                        |
+|----------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `the request payload is overridden with the following values:` | Deep-patches `world.payload` using a DataTable of `path / type / value` rows. |
+
+#### Shared `Then` steps (`shared/request/request.then-steps.ts`)
+
+| Step                                                                                                       | Action                                                                                                                                                                |
+|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `the request should have succeeded with status code <N>`                                                   | Asserts `lastFetchResponse.status === N`. Validates `N` is a known success code.                                                                                      |
+| `the request should have failed with status code <N> and the response should contain the following error:` | Asserts HTTP status and the `ApiResponseExceptionDto` shape (error, message, statusCode, optionally validationDetails).                                               |
+| `the failed request's response should contain the following validation details:`                           | Parses `validationDetails` array and asserts each entry's fields (code, message, path, expected, origin, format, pattern, minimum, maximum, inclusive, keys, values). |
+
+---
+
+## DataTable Helpers
+
+`tests/acceptance/support/helpers/datatable.helpers.ts`
+
+All DataTable cells are raw strings. These helpers bridge the gap between Cucumber's string-only DataTable format and typed Zod schemas.
+
+### Coercion validators
+
+| Function                       | Returns                          | Behavior                                                                 |
+|--------------------------------|----------------------------------|--------------------------------------------------------------------------|
+| `zCoerceOptionalBoolean()`     | `ZodType<boolean \| undefined>`  | Empty string → `undefined`; `"true"` → `true`; `"false"` → `false`.      |
+| `zCoerceOptionalString()`      | `ZodType<string \| undefined>`   | Empty string → `undefined`; any other string passes through.             |
+| `zCoerceOptionalNumber()`      | `ZodType<number \| undefined>`   | Empty string → `undefined`; numeric string → `Number(value)`.            |
+| `zCoerceOptionalStringArray()` | `ZodType<string[] \| undefined>` | Empty string → `undefined`; comma-separated string → trimmed `string[]`. |
+
+### Row parsing helpers
+
+```ts
+// Parse all rows through schema, return T[]
+validateDataTableAndGetRows(dataTable, SCHEMA);
+
+// Parse only the first row, return T
+validateDataTableAndGetFirstRow(dataTable, SCHEMA);
+```
+
+Both throw a descriptive error if the DataTable is empty or fails Zod validation.
+
+### Defining a DataTable schema
+
+```ts
+import { z } from "zod";
+import { zCoerceOptionalBoolean, zCoerceOptionalString } from "@acceptance-support/helpers/datatable.helpers";
+
+const MY_DATATABLE_SCHEMA = z.strictObject({
+  name: z.string(),
+  isActive: zCoerceOptionalBoolean(),
+  description: zCoerceOptionalString(),
+});
+```
+
+Use `z.strictObject` to catch extra/misspelled columns at test time.
+
+---
+
+## Locale Helpers
+
+`tests/acceptance/features/step-definitions/shared/locale/`
+
+### `createZLocalizedDataTableRowSchema`
+
+Creates a Zod schema for a DataTable where each row has a `locale` column and one localized field column:
+
+```ts
+const STATEMENT_ROW_SCHEMA = createZLocalizedDataTableRowSchema("statement");
+// Produces: z.strictObject({ locale: z.enum(LOCALES), statement: z.string() })
+```
+
+Used for tables like:
+
+```gherkin
+| locale | statement                  |
+| en     | Who discovered penicillin? |
+| fr     | Qui a découvert ...        |
+```
+
+### Step helpers (`locale.steps.helpers.ts`)
+
+- `expectLocalizedTextFieldToBe(entity, field, locale, expectedValue)` — asserts a single localized field matches an expected string.
+- `expectLocalizedTextsFieldToBe(entity, field, locale, expectedValues)` — asserts an array-valued localized field (e.g. trivia) matches expected strings.
+
+---
+
+## Request Helpers
+
+`tests/acceptance/support/helpers/request.helpers.ts`
+
+### `createFetchOptions(options?)`
+
+Builds an `ofetch` `FetchOptions` object from `AppFetchOptions`:
+
+```ts
+type AppFetchOptions = {
+  apiKey?: string;       // If provided, sets the API key header (X-Api-Key)
+  locale?: string;       // Sets Accept-Language header; defaults to "*"
+  method?: string;       // HTTP method; defaults to ofetch's default (GET)
+  body?: unknown;        // JSON-serialized as request body
+};
+```
+
+If `apiKey` is `undefined`, no API key header is sent (tests the unauthenticated path).
+
+```ts
+// Authenticated GET
+createFetchOptions({ apiKey: APP_ADMIN_API_KEY });
+
+// Authenticated POST with payload
+createFetchOptions({
+  apiKey: APP_ADMIN_API_KEY,
+  method: "POST",
+  body: this.payload
+});
+
+// Unauthenticated (no API key header at all)
+createFetchOptions();
+
+// Scoped to a specific locale
+createFetchOptions({
+  apiKey: APP_ADMIN_API_KEY,
+  locale: "fr"
+});
+```
+
+---
+
+## Feature Files
+
+### Tagging convention
+
+```gherkin
+@question @create-question @admin
+
+Feature: Create Question as Admin
+```
+
+Tags: `@<domain>`, `@<feature-slug>`, `@<audience>` (e.g. `@admin`, `@public`).
+
+### Gherkin keyword semantics
+
+| Keyword | Purpose                                                    |
+|---------|------------------------------------------------------------|
+| `Given` | Set up DB state (fixtures) and request payload.            |
+| `When`  | Fire an HTTP request.                                      |
+| `Then`  | Assert HTTP status code and response body.                 |
+| `And`   | Continue the most recent `Given`, `When`, or `Then` block. |
+
+### Standard scenario structure
+
+```gherkin
+Scenario: Creating a question with complete data as admin
+Given the database is populated with question themes fixture set with name "five-question-themes"
+And the request payload is set from scope "question", type "creation" and name "complete"
+When the admin creates a new question with the request payload
+Then the request should have succeeded with status code 201
+And the response should contain the following admin question:
+| id    | category | status |
+| <SET> | trivia   | active |
+```
+
+### Validation error scenario structure
+
+```gherkin
+Scenario: Trying to create a question with empty English statement
+Given the database is populated with question themes fixture set with name "five-question-themes"
+And the request payload is set from scope "question", type "creation" and name "complete"
+When the request payload is overridden with the following values:
+| path                 | type   | value |
+| content.statement.en | string |       |
+And the admin creates a new question with the request payload
+Then the request should have failed with status code 400 and the response should contain the following error:
+| error       | statusCode | message                 | validationDetails |
+| Bad Request | 400        | Invalid request payload | <SET>             |
+And the failed request's response should contain the following validation details:
+| code      | message                                           | path                 | origin | minimum | inclusive |
+| too_small | Too small: expected string to have >=1 characters | content.statement.en | string | 1       | true      |
+```
+
+### `<SET>` placeholder
+
+In a Then DataTable, `<SET>` in a cell means:
+
+- The field must be present (non-null, non-undefined).
+- The actual value is captured and can be reused by subsequent steps (e.g. referencing the generated `id` in a follow-up `When` step).
+
+---
+
+## Logging & Debugging
+
+The acceptance suite captures the app's stdout and stderr into a fixed-size ring buffer during a test run. On scenario failure the buffer is flushed and the last `N` lines of application logs are printed alongside the World debug dump (last request URL, last payload, last response body).
+
+Log files written to `tests/acceptance/logs/` during a run contain the full stdout/stderr of the spawned app process.
+
+To force log output even on passing scenarios, add a breakpoint or temporarily change the condition in the `After` hook (`hooks.ts`).
+
+---
+
+## Path Aliases
+
+| Alias                    | Resolves to                       |
+|--------------------------|-----------------------------------|
+| `@acceptance-support/*`  | `tests/acceptance/support/*`      |
+| `@acceptance-features/*` | `tests/acceptance/features/*`     |
+| `@faketories/*`          | `tests/shared/utils/faketories/*` |
+| `@mocks/*`               | `tests/unit/utils/mocks/*`        |
+| `@src/*`                 | `src/*`                           |
+| `@question/*`            | `src/contexts/question/*`         |
+| `@shared/*`              | `src/shared/*`                    |
+
+---
+
+## How To: Add a New Acceptance Test
+
+Follow these steps when adding acceptance coverage for a new or existing feature.
+
+### 1. Write the feature file
+
+Create `tests/acceptance/features/contexts/<context>/<audience>/<feature-slug>.feature`.
+
+- Add tags: `@<domain> @<feature-slug> @<audience>`.
+- Write a `Feature:` block describing the capability.
+- Add one `Scenario:` per behavior (happy path, each error path, boundary cases).
+- Use existing shared steps where possible (`the request payload is set...`, `the request should have succeeded...`, etc.).
+
+### 2. Add or reuse a fixture set
+
+If the scenario needs pre-existing database data:
+
+- Check if an existing fixture set under `support/fixtures/<domain>/sets/` covers your needs.
+- If not, create a new `.fixture-set.ts` file using faketories from `@faketories/...` with deterministic IDs.
+- Register the set in `FixtureRegistry` (type) and `FIXTURE_REGISTRY` (constant), and add a `FIXTURE_INSERTERS` entry if introducing a new domain.
+- Export individual entry constants for any documents your payload or assertions will reference by ID.
+
+### 3. Add or reuse a payload
+
+If the scenario sends a request body:
+
+- Check if an existing payload under `support/payloads/<domain>/<type>/` covers your needs.
+- If not, create a new `<name>-<domain>.<type>-payload.ts` file. Build it using faketories with concrete overrides (no randomness). Reference fixture entry `_id`s where needed.
+- Register it in the `PAYLOADS` constant (`payload.constants.ts`) under the correct `scope / type / name`.
+
+### 4. Write step definitions
+
+If the feature uses steps not yet implemented:
+
+- **Given steps**: add to `step-definitions/<context>/<audience>/<domain>.<given-steps>.ts`.
+  - For DB setup: call `loadFixture(world, domain, name)`.
+- **When steps**: add to `step-definitions/<context>/<audience>/<domain>.<when-steps>.ts`.
+  - Build fetch options via `createFetchOptions({ apiKey, method, body })`.
+  - Call `this.fetchAndStoreResponse(endpoint, fetchOptions)`.
+- **Then steps**: add to `step-definitions/<context>/<audience>/<domain>.<then-steps>.ts`.
+  - Parse response with `this.expectLastResponseJson<T>(ZOD_SCHEMA)`.
+  - Assert with `expect(actual).toStrictEqual(expected)` or a helper from `helpers/`.
+
+### 5. Define DataTable schemas
+
+For any new DataTable:
+
+- Create or update `datatables/<domain>.datatables.schemas.ts` next to the step file.
+- Use `z.strictObject({...})` so unknown columns fail fast.
+- Use `zCoerceOptionalBoolean/String/Number/StringArray()` for optional columns (empty string → `undefined`).
+
+### 6. Write step helpers (for Then steps)
+
+For non-trivial response assertions:
+
+- Create or update `helpers/<domain>.steps.helpers.ts` next to the step file.
+- Helpers are pure functions — they take parsed DTO objects and DataTable rows, and use `expect` to assert. They do not register Cucumber steps.
+
+### 7. Run the suite
+
+```bash
+pnpm test:acceptance
+# or skip build if dist/ is up to date:
+SKIP_BUILD=true pnpm test:acceptance
+```
+
+Fix any failures before merging. Acceptance tests must pass in CI alongside lint, typecheck, and unit tests.
+
+---
+
+## Contacts & References
+
+- `AGENTS.md` — repository-wide conventions and stack overview.
+- `docs/ARCHITECTURE.md` — hexagonal architecture and data flow.
+- `tests/unit/README.md` — unit test guidelines.
+- `tests/shared/utils/faketories/README.md` — faketory conventions.
+- `tests/unit/utils/mocks/README.md` — mock factory conventions.

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -50,7 +50,7 @@ Feature files live under `tests/acceptance/features/`. Support code (hooks, worl
 
 ## Directory Layout
 
-```
+```text
 tests/acceptance/
   features/
     app/                             # App-level features (health, docs, metadata)
@@ -621,12 +621,12 @@ If the scenario sends a request body:
 
 If the feature uses steps not yet implemented:
 
-- **Given steps**: add to `step-definitions/<context>/<audience>/<domain>.<given-steps>.ts`.
+- **Given steps**: add to `tests/acceptance/features/step-definitions/contexts/<context>/<audience>/*.given-steps.ts` (use the `*.given-steps.ts` filename glob so multiple files may coexist).
   - For DB setup: call `loadFixture(world, domain, name)`.
-- **When steps**: add to `step-definitions/<context>/<audience>/<domain>.<when-steps>.ts`.
+- **When steps**: add to `tests/acceptance/features/step-definitions/contexts/<context>/<audience>/*.when-steps.ts`.
   - Build fetch options via `createFetchOptions({ apiKey, method, body })`.
   - Call `this.fetchAndStoreResponse(endpoint, fetchOptions)`.
-- **Then steps**: add to `step-definitions/<context>/<audience>/<domain>.<then-steps>.ts`.
+- **Then steps**: add to `tests/acceptance/features/step-definitions/contexts/<context>/<audience>/*.then-steps.ts`.
   - Parse response with `this.expectLastResponseJson<T>(ZOD_SCHEMA)`.
   - Assert with `expect(actual).toStrictEqual(expected)` or a helper from `helpers/`.
 


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to no issue.

## 🌟 Description of changes

This pull request introduces a new skill and supporting documentation for writing Cucumber/Gherkin acceptance tests for the Goat It API. It adds a comprehensive skill definition, command, and documentation pointers to guide contributors through the process of writing or completing acceptance tests, including conventions for fixtures, payloads, step definitions, and DataTable schemas. The changes also update the agent and documentation indexes to reference these new resources.

**Skill and Workflow Additions:**

* Added a detailed skill definition in `.agents/skills/write-acceptance-test/SKILL.md` that provides step-by-step instructions, templates, best practices, and reference links for writing acceptance tests, including feature files, step definitions, fixtures, payloads, and DataTable schemas.
* Added a skill pointer in `.opencode/skills/write-acceptance-test/SKILL.md` to direct users to the canonical skill definition.
* Introduced a new command in `.opencode/commands/write-acceptance-test.md` that loads the skill and guides the user through the acceptance test workflow for a given feature or endpoint.

**Documentation and Index Updates:**

* Added `docs/ACCEPTANCE-TESTS.md` as a pointer to the main acceptance test guide, describing where acceptance tests live and how they are run.
* Updated `AGENTS.md` to reference the new acceptance test documentation and skill, including pointers to `docs/ACCEPTANCE-TESTS.md`, `tests/acceptance/README.md`, and the new `/write-acceptance-test` skill.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive acceptance test guide covering Cucumber setup, test lifecycle, fixtures, payloads, step definitions, and helpers.

## Chores
* Introduced new skill and command for writing acceptance test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->