### PR TITLE
feat(ai): auto-learn skill is loaded to any build and plan agents

### DIFF
--- a/.opencode/prompts/build-with-autolearn.txt
+++ b/.opencode/prompts/build-with-autolearn.txt
@@ -1,20 +1,19 @@
 You are the Build agent with full development access (file operations, bash commands, code changes).
 
-**CRITICAL: Load auto-learn skill at session start**
+**CRITICAL: Load auto-learn skill and bootstrap AGENTS.md at session start**
 
-At the very start of this session, before engaging with the user, you MUST load the auto-learn skill by calling:
-skill({ name: "auto-learn" })
+At the very start of this session, before engaging with the user, you MUST:
 
-Once loaded, immediately inform the user:
-"✅ Auto-learn skill loaded and active for this session"
+1. Load the auto-learn skill by calling:
+   skill({ name: "auto-learn" })
+
+2. Once loaded, immediately inform the user:
+   "✅ Auto-learn skill loaded and active for this session"
+
+3. **BEFORE ANY NORMAL INTERACTION**: Read and follow AGENTS.md
+ - Always read and follow AGENTS.md first
+ - Confirm to the user: "✅ AGENTS.md read and loaded"
 
 Then continue with normal interaction.
-
-**What auto-learn does:**
-- Detects when the user provides a correction (keywords: violates, wrong, missing, should, must, etc.)
-- Searches existing docs in `.agents/skills/`, `docs/`, and `tests/` for related guidance
-- Reports findings: either "✅ Found it in [file]" or "⚠️ Not documented yet"
-- If gaps are found, prompts user to help document the lesson
-- Applies user-approved changes directly to docs
 
 Build great code with confidence knowing auto-learn is catching any guidance gaps.

--- a/.opencode/prompts/build-with-autolearn.txt
+++ b/.opencode/prompts/build-with-autolearn.txt
@@ -1,0 +1,20 @@
+You are the Build agent with full development access (file operations, bash commands, code changes).
+
+**CRITICAL: Load auto-learn skill at session start**
+
+At the very start of this session, before engaging with the user, you MUST load the auto-learn skill by calling:
+skill({ name: "auto-learn" })
+
+Once loaded, immediately inform the user:
+"✅ Auto-learn skill loaded and active for this session"
+
+Then continue with normal interaction.
+
+**What auto-learn does:**
+- Detects when the user provides a correction (keywords: violates, wrong, missing, should, must, etc.)
+- Searches existing docs in `.agents/skills/`, `docs/`, and `tests/` for related guidance
+- Reports findings: either "✅ Found it in [file]" or "⚠️ Not documented yet"
+- If gaps are found, prompts user to help document the lesson
+- Applies user-approved changes directly to docs
+
+Build great code with confidence knowing auto-learn is catching any guidance gaps.

--- a/.opencode/prompts/plan-with-autolearn.txt
+++ b/.opencode/prompts/plan-with-autolearn.txt
@@ -1,0 +1,20 @@
+You are the Plan agent in analysis/planning mode (read-only for most operations, no file changes by default).
+
+**CRITICAL: Load auto-learn skill at session start**
+
+At the very start of this session, before engaging with the user, you MUST load the auto-learn skill by calling:
+skill({ name: "auto-learn" })
+
+Once loaded, immediately inform the user:
+"✅ Auto-learn skill loaded and active for this session"
+
+Then continue with normal interaction.
+
+**What auto-learn does:**
+- Detects when the user provides a correction (keywords: violates, wrong, missing, should, must, etc.)
+- Searches existing docs in `.agents/skills/`, `docs/`, and `tests/` for related guidance
+- Reports findings: either "✅ Found it in [file]" or "⚠️ Not documented yet"
+- If gaps are found, prompts user to help document the lesson
+- Applies user-approved changes directly to docs
+
+Plan with confidence knowing auto-learn is catching any guidance gaps.

--- a/.opencode/prompts/plan-with-autolearn.txt
+++ b/.opencode/prompts/plan-with-autolearn.txt
@@ -1,20 +1,19 @@
-You are the Plan agent in analysis/planning mode (read-only for most operations, no file changes by default).
+You are the Plan agent in analysis/planning mode. When auto-learn detects guidance gaps, you propose doc patches for user approval and apply them only when explicitly approved (no direct edits without confirmation).
 
-**CRITICAL: Load auto-learn skill at session start**
+**CRITICAL: Load auto-learn skill and bootstrap AGENTS.md at session start**
 
-At the very start of this session, before engaging with the user, you MUST load the auto-learn skill by calling:
-skill({ name: "auto-learn" })
+At the very start of this session, before engaging with the user, you MUST:
 
-Once loaded, immediately inform the user:
-"✅ Auto-learn skill loaded and active for this session"
+1. Load the auto-learn skill by calling:
+   skill({ name: "auto-learn" })
+
+2. Once loaded, immediately inform the user:
+   "✅ Auto-learn skill loaded and active for this session"
+
+3. **BEFORE ANY NORMAL INTERACTION**: Read and follow AGENTS.md
+ - Always read and follow AGENTS.md first
+ - Confirm to the user: "✅ AGENTS.md read and loaded"
 
 Then continue with normal interaction.
-
-**What auto-learn does:**
-- Detects when the user provides a correction (keywords: violates, wrong, missing, should, must, etc.)
-- Searches existing docs in `.agents/skills/`, `docs/`, and `tests/` for related guidance
-- Reports findings: either "✅ Found it in [file]" or "⚠️ Not documented yet"
-- If gaps are found, prompts user to help document the lesson
-- Applies user-approved changes directly to docs
 
 Plan with confidence knowing auto-learn is catching any guidance gaps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ Reusable agent workflows are encoded as **skills** — self-contained `SKILL.md`
 
 The `auto-learn` skill enables AI agents to learn from corrections and automatically update documentation.
 
-It's loaded automatically at startup of agents sessions.
+It must be explicitly invoked at the start of an agent session by calling `skill({ name: "auto-learn" })` in the prompt configuration (see `build-with-autolearn` and `plan-with-autolearn` prompts as examples of this pattern).
+
+For OpenCode agents, the skill is automatically invoked when the agent session starts.
 
 > **Full reference**: `.agents/skills/auto-learn/SKILL.md` — canonical source for workflow, doc file selection logic, and anti-patterns.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,56 +58,9 @@ Reusable agent workflows are encoded as **skills** — self-contained `SKILL.md`
 
 The `auto-learn` skill enables AI agents to learn from corrections and automatically update documentation.
 
-It must be loaded at the start of every agentic workflow to enable real-time learning.
+It's loaded automatically at startup of agents sessions.
 
-#### How it works
-
-1. **AI generates output** that violates a rule or misses guidance
-2. **User provides a correction** (e.g., "This violates the no-switch rule. Fix it.")
-3. **AI auto-detects the correction** using keyword matching (keywords: "violates", "wrong", "required", "missing", "anti-pattern", etc.)
-4. **AI searches docs** in `.agents/skills/*.SKILL.md`, `docs/*.md`, and `tests/*/README.md`
-5. **If guidance found** → AI confirms learning: "✅ Found it in tests/unit/README.md. I'll remember this."
-6. **If guidance NOT found** → AI prompts user: "Should I add this lesson to [file]? (y/n)"
-7. **If user approves** → AI edits the file, shows diff
-
-#### Explicit doc updates
-
-Users can also explicitly invoke `/update-docs` to teach AI a lesson without running a skill first:
-
-```
-/update-docs
-
-Me: What lesson should I document?
-You: Mappers must be pure with no side effects
-Me: I found the Mappers section in docs/ARCHITECTURE.md. Should I add this constraint? (y/n)
-```
-
-#### Correction detection keywords
-
-AI detects corrections when user message contains:
-
-- **Negation**: "don't", "no", "never", "forbidden", "can't"
-- **Requirement**: "should", "must", "required", "needs", "missing"
-- **Rule violation**: "violates", "breaks", "incorrect", "wrong", "bad"
-- **Anti-pattern**: "anti-pattern", "wrong approach", "bad practice"
-- **Missing guidance**: "where's", "where is", "why didn't", "forgot"
-- **Contradiction**: "contradicts", "conflicts with", "doesn't match"
-
-If uncertain, AI asks: "Is this a correction I should learn from? (y/n)"
-
-#### Safety guarantees
-
-- **Always shows diff before committing** — User sees exact changes
-- **Requires explicit approval** — User must confirm "y" to proceed
-- **Never auto-commits** — All edits require human confirmation
-- **Git-based rollback** — `git revert <commit>` if needed
-- **No hallucination** — Only adds guidance from real corrections or explicit `/update-docs` requests
-
-#### Reference
-
-- Full workflow: `.agents/skills/auto-learn/SKILL.md`
-- OpenCode wrapper: `.opencode/skills/auto-learn/SKILL.md`
-- Command: `/update-docs`
+> **Full reference**: `.agents/skills/auto-learn/SKILL.md` — canonical source for workflow, doc file selection logic, and anti-patterns.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The `auto-learn` skill enables AI agents to learn from corrections and automatic
 
 It must be explicitly invoked at the start of an agent session by calling `skill({ name: "auto-learn" })` in the prompt configuration (see `build-with-autolearn` and `plan-with-autolearn` prompts as examples of this pattern).
 
-For OpenCode agents, the skill is automatically invoked when the agent session starts.
+For OpenCode agents, the skill is configured to run at session start via agent prompt instructions.
 
 > **Full reference**: `.agents/skills/auto-learn/SKILL.md` — canonical source for workflow, doc file selection logic, and anti-patterns.
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "autoupdate": true
+  "autoupdate": true,
+  "agent": {
+    "build": {
+      "prompt": "{file:./.opencode/prompts/build-with-autolearn.txt}"
+    },
+    "plan": {
+      "prompt": "{file:./.opencode/prompts/plan-with-autolearn.txt}"
+    }
+  }
 }


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to no issue.

## 🌟 Description of changes

This pull request introduces a new "auto-learn" skill to both the Build and Plan agents, ensuring that guidance gaps are detected and addressed during development and planning sessions. The main changes involve updating agent prompts to load this skill at session start and updating the `opencode.json` configuration to use these new prompts.

Configuration updates:

* Updated `opencode.json` to point the Build and Plan agents to new prompt files that include instructions for loading the auto-learn skill at session start.

Agent prompt enhancements:

* Added `.opencode/prompts/build-with-autolearn.txt` to instruct the Build agent to load the auto-learn skill, inform the user, and describe how auto-learn detects corrections, checks documentation, and helps fill gaps.
* Added `.opencode/prompts/plan-with-autolearn.txt` to provide similar auto-learn instructions for the Plan agent, tailored for its planning/analysis role.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
 * Build and Plan agents now run an auto-learn bootstrap at session start, notify users when the skill is active, and confirm that AGENTS.md has been read.
 * Plan agent will propose documentation patch suggestions and apply changes only after explicit user approval.

* **Configuration**
 * New agent configuration entries enable the auto-learn prompt for build and plan modes.

* **Documentation**
 * Auto-learn guidance consolidated to a single canonical reference and in‑repo guidance simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
