### PR TITLE
refactor(logger): simplify logger mocking logic in tests

### DIFF
--- a/tests/unit/setup/mocks.setup.ts
+++ b/tests/unit/setup/mocks.setup.ts
@@ -1,7 +1,6 @@
-import { beforeAll } from "vitest";
+import { getMockedLoggerInstance } from "@mocks/shared/nest/nest.mock";
 
-import { mockNestCommon } from "@mocks/shared/nest/nest.mock";
-
-beforeAll(() => {
-  mockNestCommon();
-});
+vi.mock("@nestjs/common", async importActual => ({
+  ...await importActual(),
+  Logger: vi.fn<() => ReturnType<typeof getMockedLoggerInstance>>(getMockedLoggerInstance),
+}));

--- a/tests/unit/utils/mocks/shared/nest/nest.mock.ts
+++ b/tests/unit/utils/mocks/shared/nest/nest.mock.ts
@@ -7,20 +7,10 @@ const mockedLogger = vi.hoisted(() => ({
   fatal: vi.fn<(message: unknown, trace?: string, ...optionalParameters: unknown[]) => void>(),
 }));
 
-function mockNestCommon(): void {
-  vi.mock("@nestjs/common", async importActual => ({
-    ...await importActual(),
-    Logger: vi.fn<() => typeof mockedLogger>(function logger() {
-      return mockedLogger;
-    }),
-  }));
-}
-
 function getMockedLoggerInstance(): typeof mockedLogger {
   return mockedLogger;
 }
 
 export {
-  mockNestCommon,
   getMockedLoggerInstance,
 };


### PR DESCRIPTION
## 🔗 Related issue(s)

Related to no issue.

## 🌟 Description of changes

This pull request refactors how the `@nestjs/common` `Logger` is mocked in unit tests. The main change is to move the mocking logic directly into the test setup file, removing the indirection through a helper function. This simplifies the test setup and makes the mocking behavior clearer.

**Test mocking improvements:**

* The `Logger` class from `@nestjs/common` is now mocked directly in `tests/unit/setup/mocks.setup.ts` using `vi.mock`, replacing the previous approach that used a `mockNestCommon` helper function. This makes the mocking setup more explicit and easier to follow.
* The unused `mockNestCommon` function was removed from `tests/unit/utils/mocks/shared/nest/nest.mock.ts`, reducing unnecessary code.

## 📔 Notes for reviewers (optional)

<!-- Anything specific reviewers should focus on? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- [ ] My branch is based on `develop` and up-to-date. The PR targets the `develop` branch.
- [ ] Branch name follows the repo pattern (e.g. `feat/...`).
- [ ] PR title follows Conventional Commits format.
- [ ] I ran type checks and unit, mutation, acceptance tests locally.
- [ ] I added/updated documentation when relevant.

Thank you for your contribution! ❤️

------------------------------------------------------------------------>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
 * Enhanced test mock initialization strategy for improved test isolation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
