### PR TITLE
perf(vitest): switch test pool from forks to threads

### DIFF
--- a/configs/vitest/vitest.config.ts
+++ b/configs/vitest/vitest.config.ts
@@ -13,6 +13,7 @@ const swcJsc = SwcConfig.jsc as unknown as JscConfig;
 
 export default defineConfig({
   test: {
+    pool: "threads",
     watch: false,
     globals: true,
     clearMocks: true,

--- a/src/app/providers/services/app.service.spec.ts
+++ b/src/app/providers/services/app.service.spec.ts
@@ -1,15 +1,8 @@
 import { Test } from "@nestjs/testing";
 
-import { AppService } from "@app/providers/services/app.service";
+import packageJson from "@package-json" with { type: "json" };
 
-vi.mock(import("@package-json"), async importOriginal => ({
-  default: {
-    ...await importOriginal(),
-    name: "goat-it-api",
-    description: "API for Goat It application.",
-    version: "1.0.0",
-  },
-}));
+import { AppService } from "@app/providers/services/app.service";
 
 describe("App Service", () => {
   let services: { app: AppService };
@@ -23,10 +16,10 @@ describe("App Service", () => {
   describe("getApiMeta", () => {
     it("should return Api metadata when called.", () => {
       expect(services.app.getApiMeta()).toStrictEqual({
-        packageName: "goat-it-api",
+        packageName: packageJson.name,
         name: "Goat It API",
-        description: "API for Goat It application.",
-        version: "1.0.0",
+        description: packageJson.description,
+        version: packageJson.version,
       });
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
 * Updated test expectations to use the app’s package metadata directly, keeping assertions aligned with the current app name, description, and version.
 * Improved test execution settings to run with thread-based pooling for better test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
