### PR TITLE
fix(ci): remove skip ci token from sync-develop merge message

### DIFF
--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -80,7 +80,7 @@ jobs:
           git config user.name "GitHub Actions"
           git fetch --all
           git checkout develop
-          git merge origin/main --no-ff -m "chore: sync release v${RELEASE_VERSION} from main [skip ci]"
+          git merge origin/main --no-ff -m "chore: sync release v${RELEASE_VERSION} from main"
           git push origin develop
 
   unit-tests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
 * Updated release synchronization commit messages so they no longer include the `[skip ci]` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
