### PR TITLE
feat(translate-questions): add option to mark questions as French-only via applicableLocales

### DIFF
--- a/.opencode/commands/translate-questions.md
+++ b/.opencode/commands/translate-questions.md
@@ -92,7 +92,7 @@ Options: `["Translate to all missing locales", "Mark as French-only (applicableL
 
 - **Translate to all missing locales** → continue to step 4d.
 - **Mark as French-only** → skip translation; jump directly to step 4g (case 2) to PATCH `applicableLocales: ["fr"]`.
-- **Skip this question** → move to the next question.
+- **Skip this question** → record `{questionId}: skipped (reason: skipped by user)` in the running issues list, output `✗ Question {questionId} skipped (skipped by user)`, and move to the next question.
 - **Halt command** → stop the entire command.
 
 When choosing "Mark as French-only", the command will not translate content; the question will only be visible to French players. Use this option when:
@@ -141,7 +141,7 @@ Options: `["Approve", "Reject"]`
 - If **Reject** → ask the user what to do via `question` tool: `["Mark as French-only (skip translation)", "Provide manual English translation", "Skip this question", "Halt command"]`.
   - **Mark as French-only**: jump directly to step 4g (case 2) to PATCH `applicableLocales: ["fr"]`.
   - **Manual**: user provides the English translations; use those instead, then continue at step 4f.
-  - **Skip**: move to the next question.
+  - **Skip**: record `{questionId}: skipped (reason: skipped by user during approval)` in the running issues list, output `✗ Question {questionId} skipped (skipped by user during approval)`, and move to the next question.
   - **Halt**: stop the entire command.
 - If **Approve** → proceed to step 4f.
 
@@ -219,13 +219,14 @@ Example payload (if `context` and `trivia` also need translation):
 }
 ```
 
-Execute the PATCH:
+Execute the PATCH and capture both the response body and the HTTP status code (printed on the last line via -w):
 
 ```bash
 curl -s -X PATCH "{baseUrl}/admin/questions/{questionId}" \
   -H "Content-Type: application/json" \
   -H "goat-it-api-key: {apiKey}" \
-  -d '{payload}'
+  -d '{payload}' \
+  -w "\n%{http_code}"
 ```
 
 **Case 2: Marking as French-only** (from step 4c or 4e reject)
@@ -238,13 +239,14 @@ Send only the `applicableLocales` field:
 }
 ```
 
-Execute the PATCH:
+Execute the PATCH and capture both the response body and the HTTP status code (printed on the last line via -w):
 
 ```bash
 curl -s -X PATCH "{baseUrl}/admin/questions/{questionId}" \
   -H "Content-Type: application/json" \
   -H "goat-it-api-key: {apiKey}" \
-  -d '{"applicableLocales": ["fr"]}'
+  -d '{"applicableLocales": ["fr"]}' \
+  -w "\n%{http_code}"
 ```
 
 #### 4h. Handle errors
@@ -255,7 +257,7 @@ If the PATCH returns a non-`200` status:
 - Ask via `question` tool: `["Retry", "Mark as French-only", "Skip this question", "Halt command"]`.
   - **Retry**: go back to step 4d (translation case) or step 4g case 2 (French-only case) with the error context.
   - **Mark as French-only** (translation case only): switch to step 4g case 2.
-  - **Skip**: move to the next question.
+  - **Skip**: record `{questionId}: skipped (reason: skipped by user after PATCH error)` in the running issues list, output `✗ Question {questionId} skipped (skipped by user after PATCH error)`, and move to the next question.
   - **Halt**: stop the entire command.
 
 #### 4i. Verify question is fully handled
@@ -277,7 +279,7 @@ curl -s "{baseUrl}/admin/questions/{questionId}" \
   - **Skip**: record this question as skipped (with reason: "incomplete after patch"), output `✗ Question {id} skipped (incomplete)`, and move to the next question.
   - **Halt**: record this question as halted (with reason: "incomplete after patch"), output `✗ Question {id} halted (incomplete)`, and stop the entire command.
   Record the selected outcome (and question ID) in a running list of issues to include in the final summary.
-- If complete → output `✓ Question {id} fully translated` (translation case) or `✓ Question {id} marked as French-only` (French-only case) and move to the next question.
+- If complete → output `✓ Question {id} fully translated` (translation case) or `✓ Question {id} marked as French-only` (French-only case), increment `translated_count` (translation case) or `french_only_count` (French-only case) by exactly 1, then move to the next question.
 
 ### 5. Completion
 
@@ -312,3 +314,19 @@ Then list each problematic question with its ID and reason:
 - {questionId}: halted (reason: {reason})
 - {questionId}: error (reason: {reason})
 ```
+
+### 6. Lessons learned
+
+After the finish report, run a short retrospective and offer to improve **this command**:
+
+1. **Collect findings** from the session:
+   - Translations the user accepted as-is or rewrote manually (candidate style entries: tone, terminology, locale conventions).
+   - Decisions to mark questions as French-only that the user later reversed (candidate heuristic entries: when to suggest French-only proactively).
+   - Per-question choices the user rejected (translate vs French-only vs skip) and the reasoning they gave.
+   - Loop friction: ambiguous wording, misleading verification outputs, partial API responses that the agent had to re-interpret.
+   - Any explicit user feedback during approval questions or issue reviews.
+2. **Propose improvements** — map each finding to a concrete edit of `.opencode/commands/translate-questions.md` (step wording, verification logic, summary format, locale list, French-only heuristics). Present them as a table: improvement → lessons addressed, then ask via the question tool which to apply.
+3. **Never modify the command without explicit user approval.**
+4. **Apply approved edits** directly, verify each landed by re-reading/grepping the edited sections, and report where each change lives.
+
+Skip this step only when the user explicitly closes the session first; otherwise always offer it.

--- a/.opencode/commands/translate-questions.md
+++ b/.opencode/commands/translate-questions.md
@@ -1,5 +1,5 @@
 ---
-description: Translate all not-fully-translated questions from French source to all other locales via the admin API.
+description: Translate all not-fully-translated questions from French source to all other locales via the admin API, or mark them as French-only via applicableLocales when translation is not relevant.
 agent: build
 ---
 
@@ -7,13 +7,20 @@ agent: build
 
 ## Task
 
-Translate all not-fully-translated questions from French source to all other locales (`en`, `es`, `de`, `it`, `pt`).
+For each question that is not fully translated, either translate it from French (`fr`) to all other locales (`en`, `es`, `de`, `it`, `pt`) **or** mark it as French-only via `applicableLocales: ["fr"]` when translation is not relevant.
 
 - French (`fr`) is the **source of truth** and must **NEVER** be modified or included in any PATCH payload.
-- With a single `PATCH /admin/questions/:id`, translate all missing locales of one question.
-- The command is over when **ALL** questions are fully translated.
+- With a single `PATCH /admin/questions/:id`:
+  - Translate all missing locales of one question (`content` payload), **OR**
+  - Set `applicableLocales: ["fr"]` to restrict the question to French only (no content translation needed).
+- The command is over when **ALL** questions are either fully translated OR have `applicableLocales` restricting them to `["fr"]`.
 
-**IMPORTANT**: Questions MUST be translated **ONE AT A TIME**. Never batch questions. Each question must be fully processed (displayed, translated, approved by user, PATCHed, verified) before fetching and starting the next one. The reviewer must re-read each translation individually.
+**IMPORTANT**: Questions MUST be processed **ONE AT A TIME**. Never batch questions. Each question must be fully processed (displayed, decided, PATCHed, verified) before fetching and starting the next one. The reviewer must re-read each translation individually.
+
+**Marking as French-only** is appropriate when translation would not be relevant. Examples:
+- **Lexicon questions** — the answer is a French-specific term; would be too easy or meaningless in another language.
+- **French-culture questions** — content is too tied to French culture to be meaningful for non-French players.
+- **Puns, wordplay, or jokes** — French-language specific humor that does not translate.
 
 ## Instructions
 
@@ -49,22 +56,26 @@ curl -s "{baseUrl}/admin/questions?is-fully-translated=false&limit=100&sort-by=c
 ```
 
 - If the response is an **empty array** → output "All questions are fully translated." and stop.
-- Otherwise, store the list of questions for counting purposes, but **only fetch and process ONE question at a time** in step 4. Each question has an `id` and `content` with `statement`, `answer`, `context?`, `trivia?` — each being a localized object with optional locale keys.
+- Otherwise, store the list of questions for counting purposes, but **only fetch and process ONE question at a time** in step 4. Each question has an `id`, `category`, `applicableLocales`, and `content` with `statement`, `answer`, `context?`, `trivia?` — each being a localized object with optional locale keys.
+
+> Note: `is-fully-translated=false` already accounts for `applicableLocales`. A question with `applicableLocales: ["fr"]` and French content for mandatory fields is **excluded** from this list (considered fully handled).
 
 ### 4. Per-question translation loop
 
-**Process ONE question at a time.** After completing all steps for a question (including verification in 4h), only then fetch the next untranslated question. Never preload or batch multiple questions.
+**Process ONE question at a time.** After completing all steps for a question (including verification in 4i), only then fetch the next untranslated question. Never preload or batch multiple questions.
 
 #### 4a. Display French source
 
 Show the user the French content for this question:
 
-| Field       | French (`fr`)                                |
-|-------------|----------------------------------------------|
-| `statement` | `{question.content.statement.fr}`            |
-| `answer`    | `{question.content.answer.fr}`               |
-| `context`   | `{question.content.context.fr}` (if present) |
-| `trivia`    | `{question.content.trivia.fr}` (if present)  |
+| Field                | Value                                                       |
+|----------------------|-------------------------------------------------------------|
+| `category`           | `{question.category}`                                       |
+| `statement`          | `{question.content.statement.fr}`                           |
+| `answer`             | `{question.content.answer.fr}`                              |
+| `context`            | `{question.content.context.fr}` (if present)                |
+| `trivia`             | `{question.content.trivia.fr}` (if present)                 |
+| `applicableLocales`  | `{question.applicableLocales ?? []}` (current restriction; `[]`/undefined = all locales) |
 
 #### 4b. Identify missing locales
 
@@ -73,7 +84,23 @@ For each content field (`statement`, `answer`, `context`, `trivia`), determine w
 - **Mandatory fields** (`statement`, `answer`): all 5 target locales must be filled.
 - **Optional fields** (`context`, `trivia`): translate only if the French source is non-null. If French is null, skip that field entirely.
 
-#### 4c. Generate English translation
+#### 4c. Decide how to proceed
+
+Ask the user via the `question` tool how to handle this question:
+
+Options: `["Translate to all missing locales", "Mark as French-only (applicableLocales = [fr])", "Skip this question", "Halt command"]`
+
+- **Translate to all missing locales** → continue to step 4d.
+- **Mark as French-only** → skip translation; jump directly to step 4g (case 2) to PATCH `applicableLocales: ["fr"]`.
+- **Skip this question** → move to the next question.
+- **Halt command** → stop the entire command.
+
+When choosing "Mark as French-only", the command will not translate content; the question will only be visible to French players. Use this option when:
+- The question is a **lexicon** one (the answer is a French-specific term that would lose meaning in another language).
+- The question is **deeply tied to French culture** that cannot be meaningfully adapted for non-French players.
+- The question relies on **puns, wordplay, or jokes** that do not translate.
+
+#### 4d. Generate English translation
 
 Translate the French content to English for all fields that need it:
 
@@ -89,7 +116,7 @@ Translation rules:
 - For `trivia` arrays, translate each element individually.
 - Keep proper nouns, brand names, and game-specific terminology consistent.
 
-#### 4d. Wait for user approval
+#### 4e. Wait for user approval
 
 Present the English translations to the user via the `question` tool:
 
@@ -111,19 +138,24 @@ Trivia (en): {proposed english trivia}    (if present)
 
 Options: `["Approve", "Reject"]`
 
-- If **Reject** → ask the user what to do via `question` tool: `["Skip this question", "Provide manual English translation", "Halt command"]`.
+- If **Reject** → ask the user what to do via `question` tool: `["Mark as French-only (skip translation)", "Provide manual English translation", "Skip this question", "Halt command"]`.
+  - **Mark as French-only**: jump directly to step 4g (case 2) to PATCH `applicableLocales: ["fr"]`.
+  - **Manual**: user provides the English translations; use those instead, then continue at step 4f.
   - **Skip**: move to the next question.
-  - **Manual**: user provides the English translations; use those instead.
   - **Halt**: stop the entire command.
-- If **Approve** → proceed to step 4e.
+- If **Approve** → proceed to step 4f.
 
-#### 4e. Auto-translate to remaining locales
+#### 4f. Auto-translate to remaining locales
 
 Using the approved English translation as a reference alongside the French source, generate translations for `es`, `de`, `it`, `pt` for all fields identified in step 4b.
 
-Apply the same translation rules as step 4c.
+Apply the same translation rules as step 4d.
 
-#### 4f. PATCH the question
+#### 4g. PATCH the question
+
+Two cases depending on the decision made in step 4c or 4e:
+
+**Case 1: Translating** (after step 4f)
 
 Build the PATCH payload. **Only include fields and locales that were missing.** Never include `fr`.
 
@@ -177,21 +209,11 @@ Example payload (if `context` and `trivia` also need translation):
       "pt": "..."
     },
     "trivia": {
-      "en": [
-        "..."
-      ],
-      "es": [
-        "..."
-      ],
-      "de": [
-        "..."
-      ],
-      "it": [
-        "..."
-      ],
-      "pt": [
-        "..."
-      ]
+      "en": ["..."],
+      "es": ["..."],
+      "de": ["..."],
+      "it": ["..."],
+      "pt": ["..."]
     }
   }
 }
@@ -206,19 +228,39 @@ curl -s -X PATCH "{baseUrl}/admin/questions/{questionId}" \
   -d '{payload}'
 ```
 
-#### 4g. Handle errors
+**Case 2: Marking as French-only** (from step 4c or 4e reject)
+
+Send only the `applicableLocales` field:
+
+```json
+{
+  "applicableLocales": ["fr"]
+}
+```
+
+Execute the PATCH:
+
+```bash
+curl -s -X PATCH "{baseUrl}/admin/questions/{questionId}" \
+  -H "Content-Type: application/json" \
+  -H "goat-it-api-key: {apiKey}" \
+  -d '{"applicableLocales": ["fr"]}'
+```
+
+#### 4h. Handle errors
 
 If the PATCH returns a non-`200` status:
 
 - Display the full response body and status code to the user.
-- Ask via `question` tool: `["Retry with modified translations", "Skip this question", "Halt command"]`.
-  - **Retry**: go back to step 4c with the error context.
+- Ask via `question` tool: `["Retry", "Mark as French-only", "Skip this question", "Halt command"]`.
+  - **Retry**: go back to step 4d (translation case) or step 4g case 2 (French-only case) with the error context.
+  - **Mark as French-only** (translation case only): switch to step 4g case 2.
   - **Skip**: move to the next question.
   - **Halt**: stop the entire command.
 
-#### 4h. Verify translation completeness
+#### 4i. Verify question is fully handled
 
-Re-fetch the question to confirm it is now fully translated:
+Re-fetch the question to confirm it is now fully handled:
 
 ```bash
 curl -s "{baseUrl}/admin/questions/{questionId}" \
@@ -226,25 +268,28 @@ curl -s "{baseUrl}/admin/questions/{questionId}" \
   -H "Accept: application/json"
 ```
 
-Check that all mandatory fields (`statement`, `answer`) have non-null values for all 6 locales (`fr`, `en`, `es`, `de`, `it`, `pt`). If optional fields were translated, verify those too.
+**For translation case:** Check that all mandatory fields (`statement`, `answer`) have non-null values for all 6 locales (`fr`, `en`, `es`, `de`, `it`, `pt`). If optional fields were translated, verify those too.
 
-- If still incomplete → display which locales/fields are missing, then ask the user via `question` tool with options: `["Retry", "Skip", "Halt"]`.
-  - **Retry**: go back to step 4c, regenerate translations for the missing fields/locales, then re-PATCH and re-verify.
+**For French-only case:** Check that `applicableLocales` is now exactly `["fr"]`.
+
+- If still incomplete → display which locales/fields (or `applicableLocales`) are missing, then ask the user via `question` tool with options: `["Retry", "Skip", "Halt"]`.
+  - **Retry**: go back to step 4d (translation case) or step 4g case 2 (French-only case), re-PATCH and re-verify.
   - **Skip**: record this question as skipped (with reason: "incomplete after patch"), output `✗ Question {id} skipped (incomplete)`, and move to the next question.
   - **Halt**: record this question as halted (with reason: "incomplete after patch"), output `✗ Question {id} halted (incomplete)`, and stop the entire command.
   Record the selected outcome (and question ID) in a running list of issues to include in the final summary.
-- If complete → output `✓ Question {id} fully translated` and move to the next question.
+- If complete → output `✓ Question {id} fully translated` (translation case) or `✓ Question {id} marked as French-only` (French-only case) and move to the next question.
 
 ### 5. Completion
 
 When all questions have been processed, output a summary.
 
-**If all questions were successfully translated (no skips, no halts, no errors):**
+**If all questions were successfully handled (no skips, no halts, no errors):**
 
 ```
 Translation complete.
 
-Questions translated: {count}
+Questions translated: {translated_count}
+Questions marked as French-only: {french_only_count}
 Locales: en, es, de, it, pt (source: fr, untouched)
 Issues: none
 ```
@@ -254,7 +299,8 @@ Issues: none
 ```
 Translation partial.
 
-Questions translated: {successfully_translated_count} / {total_count}
+Questions translated: {translated_count} / {total_count}
+Questions marked as French-only: {french_only_count} / {total_count}
 Locales: en, es, de, it, pt (source: fr, untouched)
 Issues: {count}
 ```

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode-go/mimo-v2.5-pro",
+  "model": "opencode-go/minimax-m3",
   "small_model": "opencode-go/mimo-v2.5",
   "default_agent": "orchestrator",
   "subagent_depth": 2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
 - The question translation workflow can now mark questions as French-only instead of translating them.
 - Added choices to translate, mark as French-only, skip, or stop processing.
 - Completion summaries now report French-only question counts.

- **Updates**
 - Improved handling and verification for both translated and French-only questions.
 - Updated the default AI model used by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
